### PR TITLE
Fix missing sensor settings step

### DIFF
--- a/custom_components/dynamic-energy-heatpump-optimizer/strings.json
+++ b/custom_components/dynamic-energy-heatpump-optimizer/strings.json
@@ -2,7 +2,10 @@
   "config": {
     "step": {
       "user": {
-        "title": "Dynamic Energy Heatpump Optimizer",
+        "title": "Dynamic Energy Heatpump Optimizer"
+      },
+      "sensors": {
+        "title": "Sensor settings",
         "data": {
           "price_sensor": "Electricity price sensor",
           "solar_sensor": "Solar forecast sensor",
@@ -19,7 +22,10 @@
   "options": {
     "step": {
       "init": {
-        "title": "Dynamic Energy Heatpump Optimizer",
+        "title": "Dynamic Energy Heatpump Optimizer"
+      },
+      "sensors": {
+        "title": "Sensor settings",
         "data": {
           "price_sensor": "Electricity price sensor",
           "solar_sensor": "Solar forecast sensor",


### PR DESCRIPTION
## Summary
- display sensor selections in their own config menu
- adjust options flow to use the same menu
- update strings for new step

## Testing
- `pre-commit run --files custom_components/dynamic-energy-heatpump-optimizer/config_flow.py custom_components/dynamic-energy-heatpump-optimizer/strings.json`

------
https://chatgpt.com/codex/tasks/task_e_687f4a21d5a88323b118b3d31eca9a8c