### PR TITLE
Add diagnostic sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ volwaardig mixed integer programming model is voor dit doel overbodig. De
 sensor kijkt naar de stroomprijs en verwachte zonneproductie voor de komende
 uren in combinatie met COP- en warmteverliesdata. Vervolgens wordt het meest
 voordelige uur gekozen en wordt de stooklijn dienovereenkomstig verschoven.
+
+### Werking van het algoritme
+
+1. De integratie leest de elektriciteitsprijs voor de komende `planning_horizon` uren.
+2. Voor dezelfde tijdsperiode wordt de verwachte zonneproductie opgehaald.
+3. Het warmteverlies wordt bepaald aan de hand van het gekozen energielabel en het vloeroppervlak.
+4. Met een lineaire benadering van de COP wordt het warmteverlies omgerekend naar het benodigde elektrische vermogen.
+5. De netto energiebehoefte (na aftrek van zonneproductie) wordt verdeeld over de goedkoopste uren, waarbij het maximale vermogen van de warmtepomp wordt gerespecteerd.
+6. Uit de gewogen positie van deze toewijzing volgt de uiteindelijke verschuiving van de stooklijn.
+7. De berekende kosten per uur en overige tussenresultaten zijn beschikbaar als diagnostische sensoren.

--- a/custom_components/dynamic-energy-heatpump-optimizer/translations/en.json
+++ b/custom_components/dynamic-energy-heatpump-optimizer/translations/en.json
@@ -123,7 +123,10 @@
       "total_energy_cost": {"name": "Energy Contract Cost (Total)"},
       "current_consumption_price": {"name": "Current Consumption Price"},
       "current_production_price": {"name": "Current Production Price"},
-      "current_gas_consumption_price": {"name": "Current Gas Consumption Price"}
+      "current_gas_consumption_price": {"name": "Current Gas Consumption Price"},
+      "heatpump_heat_loss": {"name": "Heat Loss"},
+      "heatpump_heat_demand": {"name": "Heat Demand"},
+      "heatpump_net_energy": {"name": "Net Energy"}
     }
     },
     "issues": {

--- a/custom_components/dynamic-energy-heatpump-optimizer/translations/nl.json
+++ b/custom_components/dynamic-energy-heatpump-optimizer/translations/nl.json
@@ -149,7 +149,10 @@
       },
       "current_gas_consumption_price": {
         "name": "Huidige gasverbruiksprijs"
-      }
+      },
+      "heatpump_heat_loss": {"name": "Warmteverlies"},
+      "heatpump_heat_demand": {"name": "Warmtevraag"},
+      "heatpump_net_energy": {"name": "Netto energie"}
     }
   },
   "issues": {


### PR DESCRIPTION
## Summary
- add internal diagnostic sensors for heat loss, demand and net energy
- document algorithm in README
- translate new sensors

## Testing
- `pre-commit run --files custom_components/dynamic-energy-heatpump-optimizer/sensor.py custom_components/dynamic-energy-heatpump-optimizer/translations/en.json custom_components/dynamic-energy-heatpump-optimizer/translations/nl.json README.md`

------
https://chatgpt.com/codex/tasks/task_e_687f58e4899883238fae12c832e5ce4a