### PR TITLE
Implement heat loss based scheduling

### DIFF
--- a/custom_components/dynamic-energy-heatpump-optimizer/config_flow.py
+++ b/custom_components/dynamic-energy-heatpump-optimizer/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     CONF_SUPPLY_TEMP_SENSOR,
     CONF_ROOM_TEMP_SENSOR,
     CONF_MAX_HEATPUMP_POWER,
+    CONF_CURRENT_POWER_SENSOR,
 )
 
 
@@ -147,6 +148,15 @@ class HeatpumpOptimizerConfigFlow(ConfigFlow, domain=DOMAIN):
                         {
                             "select": {
                                 "options": temp_options,
+                                "mode": "dropdown",
+                                "multiple": False,
+                            }
+                        }
+                    ),
+                    vol.Required(CONF_CURRENT_POWER_SENSOR): selector(
+                        {
+                            "select": {
+                                "options": energy_options,
                                 "mode": "dropdown",
                                 "multiple": False,
                             }
@@ -298,6 +308,18 @@ class HeatpumpOptimizerOptionsFlowHandler(config_entries.OptionsFlow):
                         {
                             "select": {
                                 "options": temp_options,
+                                "mode": "dropdown",
+                                "multiple": False,
+                            }
+                        }
+                    ),
+                    vol.Required(
+                        CONF_CURRENT_POWER_SENSOR,
+                        default=defaults.get(CONF_CURRENT_POWER_SENSOR, ""),
+                    ): selector(
+                        {
+                            "select": {
+                                "options": energy_options,
                                 "mode": "dropdown",
                                 "multiple": False,
                             }

--- a/custom_components/dynamic-energy-heatpump-optimizer/const.py
+++ b/custom_components/dynamic-energy-heatpump-optimizer/const.py
@@ -17,6 +17,7 @@ CONF_OUTDOOR_TEMP_SENSOR = "outdoor_temperature_sensor"
 CONF_SUPPLY_TEMP_SENSOR = "supply_temperature_sensor"
 CONF_ROOM_TEMP_SENSOR = "room_temperature_sensor"
 CONF_MAX_HEATPUMP_POWER = "max_heatpump_power"
+CONF_CURRENT_POWER_SENSOR = "current_power_sensor"
 
 # Possible source types
 SOURCE_TYPE_CONSUMPTION = "Electricity consumption"

--- a/custom_components/dynamic-energy-heatpump-optimizer/sensor.py
+++ b/custom_components/dynamic-energy-heatpump-optimizer/sensor.py
@@ -16,9 +16,14 @@ from .const import (
     CONF_HEAT_LOSS_LABEL,
     CONF_FLOOR_AREA,
     CONF_ROOM_TEMP_SENSOR,
+    CONF_CURRENT_POWER_SENSOR,
     CONF_MAX_HEATPUMP_POWER,
     CONF_PLANNING_HORIZON,
     DEFAULT_PLANNING_HORIZON,
+    COP_OUTDOOR_COEFFS,
+    COP_SUPPLY_COEFFS,
+    CONF_K_FACTOR,
+    DEFAULT_K_FACTOR,
 )
 
 import logging
@@ -85,6 +90,7 @@ class HeatpumpOptimizerSensor(SensorEntity):
             "supply_temp", "sensor.heatpump_supply_temperature"
         )
         self.room_entity = data.get(CONF_ROOM_TEMP_SENSOR, "sensor.indoor_temperature")
+        self.power_entity = data.get(CONF_CURRENT_POWER_SENSOR)
         self.max_power = float(data.get(CONF_MAX_HEATPUMP_POWER, 5.0))
         label = data.get(CONF_HEAT_LOSS_LABEL, "A/B")
         area = float(data.get(CONF_FLOOR_AREA, 0.0))
@@ -162,13 +168,72 @@ class HeatpumpOptimizerSensor(SensorEntity):
         prices = prices[: self.horizon]
         _LOGGER.debug("Parsed prices for horizon: %s", prices)
 
-        cheapest_idx = prices.index(min(prices))
-        shift = cheapest_idx - self.horizon // 2
+        outdoor_state = self.hass.states.get(self.outdoor_entity)
+        supply_state = self.hass.states.get(self.supply_entity)
+        room_state = self.hass.states.get(self.room_entity)
+        if not outdoor_state or outdoor_state.state in ("unknown", "unavailable"):
+            _LOGGER.debug("Outdoor temperature unavailable")
+            return
+        if not supply_state or supply_state.state in ("unknown", "unavailable"):
+            _LOGGER.debug("Supply temperature unavailable")
+            return
+        if not room_state or room_state.state in ("unknown", "unavailable"):
+            _LOGGER.debug("Room temperature unavailable")
+            return
+
+        try:
+            outdoor_temp = float(outdoor_state.state)
+            supply_temp = float(supply_state.state)
+            room_temp = float(room_state.state)
+        except ValueError:
+            _LOGGER.debug("Invalid temperature value")
+            return
+
+        delta_t = room_temp - outdoor_temp
+        heat_loss_kw = self.heat_loss * delta_t
+
+        a_o, b_o, c_o = COP_OUTDOOR_COEFFS
+        a_s, b_s, c_s = COP_SUPPLY_COEFFS
+        k_factor = float(self._entry.data.get(CONF_K_FACTOR, DEFAULT_K_FACTOR))
+        cop_out = a_o + b_o * outdoor_temp + c_o * outdoor_temp**2
+        cop_sup = a_s + b_s * supply_temp + c_s * supply_temp**2
+        cop = max(1.0, (cop_out + cop_sup) / 2 * k_factor)
+
+        demand_kw = heat_loss_kw / cop
+        total_energy = demand_kw * self.horizon
+
+        power_now = 0.0
+        if self.power_entity:
+            power_state = self.hass.states.get(self.power_entity)
+            if power_state and power_state.state not in ("unknown", "unavailable"):
+                try:
+                    power_now = float(power_state.state)
+                except ValueError:
+                    power_now = 0.0
+
+        max_power = max(self.max_power, power_now)
+
+        indices = sorted(range(len(prices)), key=lambda i: prices[i])
+        energy_alloc = [0.0] * len(prices)
+        remaining = total_energy
+        for idx in indices:
+            alloc = min(max_power, remaining)
+            energy_alloc[idx] = alloc
+            remaining -= alloc
+            if remaining <= 0:
+                break
+
+        if total_energy > 0:
+            weighted_avg = sum(i * energy_alloc[i] for i in range(len(prices))) / total_energy
+        else:
+            weighted_avg = 0.0
+
+        shift = round(weighted_avg - self.horizon / 2)
         shift = max(-5, min(5, shift))
 
-        _LOGGER.debug("Calculated shift: %s", shift)
+        _LOGGER.debug("Calculated shift %s with demand %.2f kW", shift, demand_kw)
 
         self._forecast = prices
         self._attr_native_value = float(shift)
-        self.demand_sensor.update_value(0.0, {"demand": []})
-        self.net_energy_sensor.update_value(0.0)
+        self.demand_sensor.update_value(demand_kw, {"demand": energy_alloc})
+        self.net_energy_sensor.update_value(total_energy)


### PR DESCRIPTION
## Summary
- add current power sensor config
- compute heat loss using indoor/outdoor delta T
- distribute total heat demand to cheapest hours based on price forecast

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6d84856c8323879d0f53094d2bb4