### PR TITLE
Fix heat loss formula implementation

### DIFF
--- a/custom_components/dynamic-energy-heatpump-optimizer/sensor.py
+++ b/custom_components/dynamic-energy-heatpump-optimizer/sensor.py
@@ -93,9 +93,9 @@ class HeatpumpOptimizerSensor(SensorEntity):
         self.power_entity = data.get(CONF_CURRENT_POWER_SENSOR)
         self.max_power = float(data.get(CONF_MAX_HEATPUMP_POWER, 5.0))
         label = data.get(CONF_HEAT_LOSS_LABEL, "A/B")
-        area = float(data.get(CONF_FLOOR_AREA, 0.0))
-        factor = HEAT_LOSS_FACTORS.get(label, 1.5)
-        self.heat_loss = factor * area / 1000.0
+        self.floor_area = float(data.get(CONF_FLOOR_AREA, 0.0))
+        self.loss_factor = HEAT_LOSS_FACTORS.get(label, 1.5)
+        self.heat_loss_per_degree = self.loss_factor * self.floor_area / 1000.0
         self.horizon = int(data.get(CONF_PLANNING_HORIZON, DEFAULT_PLANNING_HORIZON))
         self._forecast: list[float] = []
         self._demand: list[float] = []
@@ -121,7 +121,7 @@ class HeatpumpOptimizerSensor(SensorEntity):
             self.demand_sensor,
             self.net_energy_sensor,
         ]
-        self.heat_loss_sensor._attr_native_value = round(self.heat_loss, 3)
+        self.heat_loss_sensor._attr_native_value = round(self.heat_loss_per_degree, 3)
 
     @property
     def extra_state_attributes(self) -> dict[str, list[float]]:
@@ -190,7 +190,7 @@ class HeatpumpOptimizerSensor(SensorEntity):
             return
 
         delta_t = room_temp - outdoor_temp
-        heat_loss_kw = self.heat_loss * delta_t
+        heat_loss_kw = self.loss_factor * self.floor_area * delta_t / 1000.0
 
         a_o, b_o, c_o = COP_OUTDOOR_COEFFS
         a_s, b_s, c_s = COP_SUPPLY_COEFFS
@@ -224,7 +224,9 @@ class HeatpumpOptimizerSensor(SensorEntity):
                 break
 
         if total_energy > 0:
-            weighted_avg = sum(i * energy_alloc[i] for i in range(len(prices))) / total_energy
+            weighted_avg = (
+                sum(i * energy_alloc[i] for i in range(len(prices))) / total_energy
+            )
         else:
             weighted_avg = 0.0
 


### PR DESCRIPTION
## Summary
- compute heat loss using explicit formula `factor * area * ΔT / 1000`
- show resulting kW per °C value in diagnostics

## Testing
- `pre-commit run --files custom_components/dynamic-energy-heatpump-optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_687f7157de3c83239bda06190a607fb5