### PR TITLE
Fix config flow price settings initialization

### DIFF
--- a/custom_components/optimizer/config_flow.py
+++ b/custom_components/optimizer/config_flow.py
@@ -37,6 +37,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
         self.configs: list[dict] = []
         self.source_type: str | None = None
         self.sources: list[str] | None = None
+        self.price_settings: dict[str, Any] = {}
 
     async def async_step_user(
         self, user_input: dict[str, str] | None = None
@@ -187,6 +188,7 @@ class DynamicEnergyCalculatorOptionsFlowHandler(config_entries.OptionsFlow):
         self.price_settings = copy.deepcopy(
             config_entry.options.get(
                 CONF_PRICE_SETTINGS,
+                {},
             )
         )
         self.source_type: str | None = None


### PR DESCRIPTION
## Summary
- prevent attribute errors by initializing `price_settings` in config flows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688201e0b298832399dfa24ec21390b3