### PR TITLE
Add met.no forecast support

### DIFF
--- a/custom_components/optimizer/const.py
+++ b/custom_components/optimizer/const.py
@@ -16,6 +16,8 @@ CONF_PRICE_SETTINGS = "price_settings"
 CONF_AREA_M2 = "area_m2"
 CONF_ENERGY_LABEL = "energy_label"
 CONF_OUTDOOR_TEMPERATURE = "outdoor_temperature"
+# Optional weather entity providing a temperature forecast array
+CONF_OUTDOOR_FORECAST = "outdoor_forecast"
 # One or more Solcast sensors. The sensors should expose a ``detailed forecast``
 # attribute with the expected PV production for the coming hours. The raw list
 # from these attributes will be copied to the solar gain sensor attributes.


### PR DESCRIPTION
## Summary
- enable hourly heat loss forecast using met.no data
- expose forecast array as extra attributes
- choose met.no weather entity in config & options flows

## Testing
- `pre-commit run --files custom_components/optimizer/const.py custom_components/optimizer/config_flow.py custom_components/optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_688263b47c1c8323a81563a0a232ce71