### PR TITLE
Handle per-hour solar forecast

### DIFF
--- a/custom_components/optimizer/sensor.py
+++ b/custom_components/optimizer/sensor.py
@@ -13,16 +13,10 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 
-import aiohttp
-import math
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.entity import DeviceInfo
-from typing import Any, cast
+from typing import Any
 
 from .const import (
     DOMAIN,
-    CONF_PRICE_SENSOR,
-    CONF_PRICE_SETTINGS,
     SOURCE_TYPE_CONSUMPTION,
     SOURCE_TYPE_PRODUCTION,
     CONF_SOURCE_TYPE,
@@ -38,7 +32,6 @@ from .const import (
     CONF_PRICE_SETTINGS,
     CONF_SOLAR_FORECAST,
     CONF_CONFIGS,
-    U_VALUE_MAP,
     INDOOR_TEMPERATURE,
     SOLAR_EFFICIENCY,
     U_VALUE_MAP,
@@ -222,7 +215,10 @@ class SolarGainSensor(BaseUtilitySensor):
         self.area_m2 = area_m2
 
     def _extract_forecast(self, state) -> list[float]:
-        """Extract forecast list from a Solcast or Forecast.Solar sensor."""
+        """Return forecast values for the next 24h for a Solcast/Forecast.Solar sensor."""
+        from datetime import timedelta
+        from homeassistant.util import dt as dt_util
+
         for key in (
             "detailed forecast",
             "detailed_forecast",
@@ -236,23 +232,47 @@ class SolarGainSensor(BaseUtilitySensor):
         else:
             data = []
 
+        now = dt_util.utcnow()
+        end = now + timedelta(hours=24)
         values: list[float] = []
         if isinstance(data, (list, tuple)):
             for item in data:
+                ts = None
                 if isinstance(item, dict):
                     val = (
                         item.get("pv_estimate")
                         or item.get("value")
                         or item.get("energy")
                         or item.get("wh")
+                        or item.get("watts")
+                    )
+                    ts = (
+                        item.get("period_end")
+                        or item.get("period")
+                        or item.get("time")
+                        or item.get("dt")
                     )
                 else:
                     val = item
                 try:
-                    if val is not None:
-                        values.append(float(val))
+                    if val is None:
+                        continue
+                    val_float = float(val)
                 except (TypeError, ValueError):
                     continue
+
+                if ts:
+                    dt_obj = dt_util.parse_datetime(str(ts))
+                    if dt_obj is None:
+                        continue
+                    dt_obj = dt_util.as_utc(dt_obj)
+                    if dt_obj < now or dt_obj >= end:
+                        continue
+
+                if len(values) >= 24:
+                    break
+                values.append(val_float)
+
         return values
 
     @property
@@ -269,21 +289,22 @@ class SolarGainSensor(BaseUtilitySensor):
             if state is None or state.state in ("unknown", "unavailable"):
                 _LOGGER.warning("Solar forecast sensor %s is unavailable", sensor)
                 continue
-            try:
-                val = float(state.state)
-            except ValueError:
-                _LOGGER.warning("Solar forecast sensor %s has invalid state", sensor)
-                continue
-            total_solar += val
 
             forecast = self._extract_forecast(state)
-            if forecast:
-                attr_data[sensor] = forecast
-                for i, v in enumerate(forecast[:24]):
-                    if len(aggregated) <= i:
-                        aggregated.append(float(v))
-                    else:
-                        aggregated[i] += float(v)
+            if not forecast:
+                _LOGGER.warning(
+                    "Solar forecast sensor %s has no usable forecast", sensor
+                )
+                continue
+
+            attr_data[sensor] = forecast
+            total_solar += forecast[0]
+
+            for i, v in enumerate(forecast[:24]):
+                if len(aggregated) <= i:
+                    aggregated.append(float(v))
+                else:
+                    aggregated[i] += float(v)
 
         if not attr_data:
             self._attr_available = False
@@ -352,9 +373,7 @@ class WindowSolarGainSensor(BaseUtilitySensor):
         self._extra_attrs: dict[str, list[float]] = {}
 
     async def _fetch_radiation(self) -> list[float]:
-        url = (
-            "https://api.open-meteo.com/v1/forecast?latitude={self.latitude}&longitude={self.longitude}&hourly=shortwave_radiation&timezone=UTC"
-        )
+        url = "https://api.open-meteo.com/v1/forecast?latitude={self.latitude}&longitude={self.longitude}&hourly=shortwave_radiation&timezone=UTC"
         async with self.session.get(url) as resp:
             data = await resp.json()
         return [float(v) for v in data.get("hourly", {}).get("shortwave_radiation", [])]
@@ -550,7 +569,9 @@ class EnergyConsumptionForecastSensor(BaseUtilitySensor):
                     val = float(s.state)
                 except (ValueError, TypeError):
                     continue
-                ts = dt_util.as_utc(getattr(s, "last_updated", None) or dt_util.utcnow())
+                ts = dt_util.as_utc(
+                    getattr(s, "last_updated", None) or dt_util.utcnow()
+                )
                 if prev_val is None:
                     prev_val = val
                     prev_ts = ts


### PR DESCRIPTION
## 📝 What’s Changed?
- adjust `SolarGainSensor` to read forecast values by matching current time and limiting to 24h
- main state now uses first upcoming forecast value instead of sensor state

## 🔍 Why is this Change Needed?
- previously the integration summed the daily sensor states. This didn't match hourly production forecasts.

## 🧪 How Was This Tested?
- `pre-commit` ran successfully on the updated file

------
https://chatgpt.com/codex/tasks/task_e_68838071907c83239eba3ad82147d25f