### PR TITLE
Rename integration to Heating Curve Optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🔥 Heatpump Curve Optimizer
+# 🔥 Heating Curve Optimizer
 
 Deze Home Assistant custom integratie past automatisch en voorspellend de stooklijn-offset van je warmtepomp aan op basis van:
 

--- a/custom_components/optimizer/__init__.py
+++ b/custom_components/optimizer/__init__.py
@@ -24,7 +24,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     if not hass.data[DOMAIN].get("services_registered"):
         await async_register_services(hass)
         hass.data[DOMAIN]["services_registered"] = True
-    _LOGGER.info("Initialized Heatpump Curve Optimizer")
+    _LOGGER.info("Initialized Heating Curve Optimizer")
     return True
 
 

--- a/custom_components/optimizer/config_flow.py
+++ b/custom_components/optimizer/config_flow.py
@@ -35,7 +35,7 @@ STEP_BASIC = "basic"
 
 
 class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
-    """Handle a config flow for Heatpump Curve Optimizer."""
+    """Handle a config flow for Heating Curve Optimizer."""
 
     VERSION = 1
 
@@ -83,7 +83,7 @@ class DynamicEnergyCalculatorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
                         errors={"base": "no_blocks"},
                     )
                 return self.async_create_entry(
-                    title="Heatpump Curve Optimizer",
+                    title="Heating Curve Optimizer",
                     data={
                         CONF_CONFIGS: self.configs,
                         CONF_PRICE_SENSOR: self.price_settings.get(CONF_PRICE_SENSOR),

--- a/custom_components/optimizer/const.py
+++ b/custom_components/optimizer/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Heatpump Curve Optimizer integration."""
+"""Constants for the Heating Curve Optimizer integration."""
 
 # Domain of the integration
 DOMAIN = "optimizer"
@@ -12,7 +12,7 @@ CONF_SOURCES = "sources"
 CONF_PRICE_SENSOR = "price_sensor"
 CONF_PRICE_SETTINGS = "price_settings"
 
-# New configuration keys for the heatpump optimizer
+# New configuration keys for the heating curve optimizer
 CONF_AREA_M2 = "area_m2"
 CONF_ENERGY_LABEL = "energy_label"
 # Glass related configuration

--- a/custom_components/optimizer/manifest.json
+++ b/custom_components/optimizer/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "optimizer",
-  "name": "Heatpump Curve Optimizer",
+  "name": "Heating Curve Optimizer",
   "codeowners": ["@bvweerd"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/optimizer/sensor.py
+++ b/custom_components/optimizer/sensor.py
@@ -642,7 +642,7 @@ async def async_setup_entry(
     )
     device_info = DeviceInfo(
         identifiers={(DOMAIN, entry.entry_id)},
-        name="Heatpump Curve Optimizer",
+        name="Heating Curve Optimizer",
     )
     entities: list[BaseUtilitySensor] = []
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Heatpump Curve Optimizer",
+  "name": "Heating Curve Optimizer",
   "render_readme": true
 }


### PR DESCRIPTION
## Summary
- rename integration to "Heating Curve Optimizer" in README and config files

## Testing
- `pre-commit run --files README.md hacs.json custom_components/optimizer/manifest.json custom_components/optimizer/__init__.py custom_components/optimizer/config_flow.py custom_components/optimizer/const.py custom_components/optimizer/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_6883860bf8b88323a4434a1a6661bc30